### PR TITLE
refactor (plus fixes): rewrite auth logic for simplification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,32 @@
-# Required by various APIs
+# Shared by various API tutorials
 CLUSTER_ID=fill-this-in
 
-# Required for Administration API tutorial, to acquire auth tokens
-#  See https://docs.camunda.io/docs/apis-tools/administration-api/authentication/#client-credentials-and-scopes
+------------------------------------
+
+# Administration API tutorial
+
+## Capture these values from an API client created at the organization level, with access to the Cluster scope.
+##  See https://docs.camunda.io/docs/apis-tools/administration-api/authentication/#client-credentials-and-scopes for more details.
+### This value comes from the `CAMUNDA_CONSOLE_CLIENT_ID`.
 ADMINISTRATION_CLIENT_ID=fill-this-in
+### This value comes from the `CAMUNDA_CONSOLE_CLIENT_SECRET`.
 ADMINISTRATION_CLIENT_SECRET=fill-this-in
+
+## These values will only change if you're not using SaaS.
 ADMINISTRATION_AUDIENCE=api.cloud.camunda.io
-# Required for Administration API tutorial, to access API
 ADMINISTRATION_API_URL=https://api.cloud.camunda.io
 
 ------------------------------------
 
-# Required for Optimize API tutorials, to acquire auth tokens
+# Optimize API tutorial
+
+## Capture these values from an API client created at the cluster level, with access to the Optimize scope.
+### This value comes from the `ZEEBE_CLIENT_ID`.
 OPTIMIZE_CLIENT_ID=fill-this-in
+### This value comes from the `ZEEBE_CLIENT_SECRET`.
 OPTIMIZE_CLIENT_SECRET=fill-this-in
-OPTIMIZE_AUDIENCE=optimize.camunda.io
-# Required for Optimize API tutorial, to access API
+### This value comes from the `CAMUNDA_OPTIMIZE_BASE_URL`.
 OPTIMIZE_BASE_URL=fill-this-in
+
+## This value will only change if you're not using SaaS.
+OPTIMIZE_AUDIENCE=optimize.camunda.io

--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,19 @@
+# Required by various APIs
+CLUSTER_ID=fill-this-in
+
 # Required for Administration API tutorial, to acquire auth tokens
 #  See https://docs.camunda.io/docs/apis-tools/administration-api/authentication/#client-credentials-and-scopes
 ADMINISTRATION_CLIENT_ID=fill-this-in
 ADMINISTRATION_CLIENT_SECRET=fill-this-in
-
+ADMINISTRATION_AUDIENCE=api.cloud.camunda.io
 # Required for Administration API tutorial, to access API
 ADMINISTRATION_API_URL=https://api.cloud.camunda.io
-ADMINISTRATION_AUDIENCE=api.cloud.camunda.io
-CLUSTER_ID=fill-this-in
 
 ------------------------------------
 
-# Required for non-Administration API tutorials, to acquire auth tokens
-COMPONENTS_CLIENT_ID=fill-this-in
-COMPONENTS_CLIENT_SECRET=fill-this-in
-
+# Required for Optimize API tutorials, to acquire auth tokens
+OPTIMIZE_CLIENT_ID=fill-this-in
+OPTIMIZE_CLIENT_SECRET=fill-this-in
+OPTIMIZE_AUDIENCE=optimize.camunda.io
 # Required for Optimize API tutorial, to access API
 OPTIMIZE_BASE_URL=fill-this-in
-OPTIMIZE_AUDIENCE=optimize.camunda.io

--- a/administration.js
+++ b/administration.js
@@ -1,167 +1,20 @@
 import axios from "axios";
 import { getAccessToken } from "./auth.js";
 
-const authorizationConfiguration = {
-  clientId: process.env.ADMINISTRATION_CLIENT_ID,
-  clientSecret: process.env.ADMINISTRATION_CLIENT_SECRET,
-  audience: process.env.ADMINISTRATION_AUDIENCE
-};
-
-// An action that lists all clients.
 async function listClients() {
-  // Every request needs an access token.
-  const accessToken = await getAccessToken(authorizationConfiguration);
-
-  // These settings come from your .env file.
-  const administrationApiUrl = process.env.ADMINISTRATION_API_URL;
-  const clusterId = process.env.CLUSTER_ID;
-
-  // This is the API endpoint to list all clients within a cluster.
-  const url = `${administrationApiUrl}/clusters/${clusterId}/clients`;
-
-  // Configure the API call.
-  const options = {
-    method: "GET",
-    url,
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${accessToken}`
-    }
-  };
-
-  try {
-    // Call the clients endpoint.
-    const response = await axios(options);
-
-    // Process the results from the API call.
-    const results = response.data;
-
-    // Emit clients to output.
-    results.forEach(x => console.log(`Name: ${x.name}; ID: ${x.clientId}`));
-  } catch (error) {
-    // Emit an error from the server.
-    console.error(error.message);
-  }
+  console.log("listing clients");
 }
 
-// An action that adds a new client.
 async function addClient([clientName]) {
-  // Every request needs an access token.
-  const accessToken = await getAccessToken(authorizationConfiguration);
-
-  // These settings come from your .env file.
-  const administrationApiUrl = process.env.ADMINISTRATION_API_URL;
-  const clusterId = process.env.CLUSTER_ID;
-
-  // This is the API endpoint to add a new client to a cluster.
-  const url = `${administrationApiUrl}/clusters/${clusterId}/clients`;
-
-  // Configure the API call.
-  const options = {
-    method: "POST",
-    url,
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${accessToken}`
-    },
-    data: {
-      // The body contains information about the new client.
-      clientName: clientName
-    }
-  };
-
-  try {
-    // Call the add endpoint.
-    const response = await axios(options);
-
-    // Process the results from the API call.
-    const newClient = response.data;
-
-    // Emit new client to output.
-    //  NOTE: In real life, you probably want to capture the
-    //    `clientSecret` property from the response, since it can't be displayed again.
-    console.log(
-      `Client added! Name: ${newClient.name}. ID: ${newClient.clientId}.`
-    );
-  } catch (error) {
-    // Emit an error from the server.
-    console.error(error.message);
-  }
+  console.log(`adding client ${clientName}`);
 }
 
-// An action that views one client.
 async function viewClient([clientId]) {
-  // Every request needs an access token.
-  const accessToken = await getAccessToken(authorizationConfiguration);
-
-  // These settings come from your .env file.
-  const administrationApiUrl = process.env.ADMINISTRATION_API_URL;
-  const clusterId = process.env.CLUSTER_ID;
-
-  // This is the API endpoint to view a single client within a cluster.
-  const url = `${administrationApiUrl}/clusters/${clusterId}/clients/${clientId}`;
-
-  // Call the client endpoint.
-  const options = {
-    method: "GET",
-    url,
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${accessToken}`
-    }
-  };
-
-  try {
-    const response = await axios(options);
-
-    // Process the results from the API call.
-    const clientResponse = response.data;
-
-    // Emit the client details.
-    console.log("Client:", clientResponse);
-  } catch (error) {
-    // Emit an error from the server.
-    console.error(error.message);
-  }
+  console.log(`viewing client ${clientId}`);
 }
 
-// An action that deletes a client.
 async function deleteClient([clientId]) {
-  // Every request needs an access token.
-  const accessToken = await getAccessToken(authorizationConfiguration);
-
-  // These settings come from your .env file.
-  const administrationApiUrl = process.env.ADMINISTRATION_API_URL;
-  const clusterId = process.env.CLUSTER_ID;
-
-  // This is the API endpoint to delete a client from a cluster.
-  const url = `${administrationApiUrl}/clusters/${clusterId}/clients/${clientId}`;
-
-  // Configure the API call.
-  const options = {
-    method: "DELETE",
-    url,
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${accessToken}`
-    }
-  };
-
-  try {
-    // Call the delete endpoint.
-    const response = await axios(options);
-
-    // Process the results from the API call.
-    if (response.status === 204) {
-      console.log(`Client ${clientId} was deleted!`);
-    } else {
-      // Emit an unexpected error message.
-      console.error("Unable to delete client!");
-    }
-  } catch (error) {
-    // Emit an error from the server.
-    console.error(error.message);
-  }
+  console.log(`deleting client ${clientId}`);
 }
 
 // These functions are aliased to specific command names for terseness.

--- a/administration.js
+++ b/administration.js
@@ -91,13 +91,8 @@ async function addClient([clientName]) {
 
 // An action that views one client.
 async function viewClient([clientId]) {
-  const administrationAudience = process.env.ADMINISTRATION_AUDIENCE;
-
   // Every request needs an access token.
-  const accessToken = await getAccessToken(
-    "administration",
-    administrationAudience
-  );
+  const accessToken = await getAccessToken(authorizationConfiguration);
 
   // These settings come from your .env file.
   const administrationApiUrl = process.env.ADMINISTRATION_API_URL;

--- a/administration.js
+++ b/administration.js
@@ -127,13 +127,8 @@ async function viewClient([clientId]) {
 
 // An action that deletes a client.
 async function deleteClient([clientId]) {
-  const administrationAudience = process.env.ADMINISTRATION_AUDIENCE;
-
   // Every request needs an access token.
-  const accessToken = await getAccessToken(
-    "administration",
-    administrationAudience
-  );
+  const accessToken = await getAccessToken(authorizationConfiguration);
 
   // These settings come from your .env file.
   const administrationApiUrl = process.env.ADMINISTRATION_API_URL;

--- a/administration.js
+++ b/administration.js
@@ -1,20 +1,182 @@
 import axios from "axios";
 import { getAccessToken } from "./auth.js";
 
+const authorizationConfiguration = {
+  clientId: process.env.ADMINISTRATION_CLIENT_ID,
+  clientSecret: process.env.ADMINISTRATION_CLIENT_SECRET,
+  audience: process.env.ADMINISTRATION_AUDIENCE
+};
+
+// An action that lists all clients.
 async function listClients() {
-  console.log("listing clients");
+  // Every request needs an access token.
+  const accessToken = await getAccessToken(authorizationConfiguration);
+
+  // These settings come from your .env file.
+  const administrationApiUrl = process.env.ADMINISTRATION_API_URL;
+  const clusterId = process.env.CLUSTER_ID;
+
+  // This is the API endpoint to list all clients within a cluster.
+  const url = `${administrationApiUrl}/clusters/${clusterId}/clients`;
+
+  // Configure the API call.
+  const options = {
+    method: "GET",
+    url,
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${accessToken}`
+    }
+  };
+
+  try {
+    // Call the clients endpoint.
+    const response = await axios(options);
+
+    // Process the results from the API call.
+    const results = response.data;
+
+    // Emit clients to output.
+    results.forEach(x => console.log(`Name: ${x.name}; ID: ${x.clientId}`));
+  } catch (error) {
+    // Emit an error from the server.
+    console.error(error.message);
+  }
 }
 
+// An action that adds a new client.
 async function addClient([clientName]) {
-  console.log(`adding client ${clientName}`);
+  const administrationAudience = process.env.ADMINISTRATION_AUDIENCE;
+
+  // Every request needs an access token.
+  const accessToken = await getAccessToken(
+    "administration",
+    administrationAudience
+  );
+
+  // These settings come from your .env file.
+  const administrationApiUrl = process.env.ADMINISTRATION_API_URL;
+  const clusterId = process.env.CLUSTER_ID;
+
+  // This is the API endpoint to add a new client to a cluster.
+  const url = `${administrationApiUrl}/clusters/${clusterId}/clients`;
+
+  // Configure the API call.
+  const options = {
+    method: "POST",
+    url,
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${accessToken}`
+    },
+    data: {
+      // The body contains information about the new client.
+      clientName: clientName
+    }
+  };
+
+  try {
+    // Call the add endpoint.
+    const response = await axios(options);
+
+    // Process the results from the API call.
+    const newClient = response.data;
+
+    // Emit new client to output.
+    //  NOTE: In real life, you probably want to capture the
+    //    `clientSecret` property from the response, since it can't be displayed again.
+    console.log(
+      `Client added! Name: ${newClient.name}. ID: ${newClient.clientId}.`
+    );
+  } catch (error) {
+    // Emit an error from the server.
+    console.error(error.message);
+  }
 }
 
+// An action that views one client.
 async function viewClient([clientId]) {
-  console.log(`viewing client ${clientId}`);
+  const administrationAudience = process.env.ADMINISTRATION_AUDIENCE;
+
+  // Every request needs an access token.
+  const accessToken = await getAccessToken(
+    "administration",
+    administrationAudience
+  );
+
+  // These settings come from your .env file.
+  const administrationApiUrl = process.env.ADMINISTRATION_API_URL;
+  const clusterId = process.env.CLUSTER_ID;
+
+  // This is the API endpoint to view a single client within a cluster.
+  const url = `${administrationApiUrl}/clusters/${clusterId}/clients/${clientId}`;
+
+  // Call the client endpoint.
+  const options = {
+    method: "GET",
+    url,
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${accessToken}`
+    }
+  };
+
+  try {
+    const response = await axios(options);
+
+    // Process the results from the API call.
+    const clientResponse = response.data;
+
+    // Emit the client details.
+    console.log("Client:", clientResponse);
+  } catch (error) {
+    // Emit an error from the server.
+    console.error(error.message);
+  }
 }
 
+// An action that deletes a client.
 async function deleteClient([clientId]) {
-  console.log(`deleting client ${clientId}`);
+  const administrationAudience = process.env.ADMINISTRATION_AUDIENCE;
+
+  // Every request needs an access token.
+  const accessToken = await getAccessToken(
+    "administration",
+    administrationAudience
+  );
+
+  // These settings come from your .env file.
+  const administrationApiUrl = process.env.ADMINISTRATION_API_URL;
+  const clusterId = process.env.CLUSTER_ID;
+
+  // This is the API endpoint to delete a client from a cluster.
+  const url = `${administrationApiUrl}/clusters/${clusterId}/clients/${clientId}`;
+
+  // Configure the API call.
+  const options = {
+    method: "DELETE",
+    url,
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${accessToken}`
+    }
+  };
+
+  try {
+    // Call the delete endpoint.
+    const response = await axios(options);
+
+    // Process the results from the API call.
+    if (response.status === 204) {
+      console.log(`Client ${clientId} was deleted!`);
+    } else {
+      // Emit an unexpected error message.
+      console.error("Unable to delete client!");
+    }
+  } catch (error) {
+    // Emit an error from the server.
+    console.error(error.message);
+  }
 }
 
 // These functions are aliased to specific command names for terseness.

--- a/administration.js
+++ b/administration.js
@@ -46,13 +46,8 @@ async function listClients() {
 
 // An action that adds a new client.
 async function addClient([clientName]) {
-  const administrationAudience = process.env.ADMINISTRATION_AUDIENCE;
-
   // Every request needs an access token.
-  const accessToken = await getAccessToken(
-    "administration",
-    administrationAudience
-  );
+  const accessToken = await getAccessToken(authorizationConfiguration);
 
   // These settings come from your .env file.
   const administrationApiUrl = process.env.ADMINISTRATION_API_URL;

--- a/completed/administration.js
+++ b/completed/administration.js
@@ -1,15 +1,16 @@
 import axios from "axios";
 import { getAccessToken } from "./auth.js";
 
+const authorizationConfiguration = {
+  clientId: process.env.ADMINISTRATION_CLIENT_ID,
+  clientSecret: process.env.ADMINISTRATION_CLIENT_SECRET,
+  audience: process.env.ADMINISTRATION_AUDIENCE
+};
+
 // An action that lists all clients.
 async function listClients() {
-  const administrationAudience = process.env.ADMINISTRATION_AUDIENCE;
-
   // Every request needs an access token.
-  const accessToken = await getAccessToken(
-    "administration",
-    administrationAudience
-  );
+  const accessToken = await getAccessToken(authorizationConfiguration);
 
   // These settings come from your .env file.
   const administrationApiUrl = process.env.ADMINISTRATION_API_URL;
@@ -45,13 +46,8 @@ async function listClients() {
 
 // An action that adds a new client.
 async function addClient([clientName]) {
-  const administrationAudience = process.env.ADMINISTRATION_AUDIENCE;
-
   // Every request needs an access token.
-  const accessToken = await getAccessToken(
-    "administration",
-    administrationAudience
-  );
+  const accessToken = await getAccessToken(authorizationConfiguration);
 
   // These settings come from your .env file.
   const administrationApiUrl = process.env.ADMINISTRATION_API_URL;
@@ -95,13 +91,8 @@ async function addClient([clientName]) {
 
 // An action that views one client.
 async function viewClient([clientId]) {
-  const administrationAudience = process.env.ADMINISTRATION_AUDIENCE;
-
   // Every request needs an access token.
-  const accessToken = await getAccessToken(
-    "administration",
-    administrationAudience
-  );
+  const accessToken = await getAccessToken(authorizationConfiguration);
 
   // These settings come from your .env file.
   const administrationApiUrl = process.env.ADMINISTRATION_API_URL;
@@ -136,13 +127,8 @@ async function viewClient([clientId]) {
 
 // An action that deletes a client.
 async function deleteClient([clientId]) {
-  const administrationAudience = process.env.ADMINISTRATION_AUDIENCE;
-
   // Every request needs an access token.
-  const accessToken = await getAccessToken(
-    "administration",
-    administrationAudience
-  );
+  const accessToken = await getAccessToken(authorizationConfiguration);
 
   // These settings come from your .env file.
   const administrationApiUrl = process.env.ADMINISTRATION_API_URL;

--- a/completed/optimize.js
+++ b/completed/optimize.js
@@ -59,7 +59,7 @@ async function deleteDashboard([dashboardId]) {
 
     // Process the results from the API call.
     if (response.status === 204) {
-      console.log(`Dashboard ${clientId} was deleted!`);
+      console.log(`Dashboard ${dashboardId} was deleted!`);
     } else {
       // Emit an unexpected error message.
       console.error("Unable to delete dashboard!");

--- a/completed/optimize.js
+++ b/completed/optimize.js
@@ -1,9 +1,14 @@
 import axios from "axios";
 import { getAccessToken } from "./auth.js";
 
+const authorizationConfiguration = {
+  clientId: process.env.OPTIMIZE_CLIENT_ID,
+  clientSecret: process.env.OPTIMIZE_CLIENT_SECRET,
+  audience: process.env.OPTIMIZE_AUDIENCE
+};
+
 async function listDashboards([collectionId]) {
-  const optimizeAudience = process.env.OPTIMIZE_AUDIENCE;
-  const accessToken = await getAccessToken("components", optimizeAudience);
+  const accessToken = await getAccessToken(authorizationConfiguration);
 
   const optimizeApiUrl = process.env.OPTIMIZE_BASE_URL;
   // This is the API endpoint to list your existing dashboard IDs

--- a/completed/optimize.js
+++ b/completed/optimize.js
@@ -38,11 +38,10 @@ async function listDashboards([collectionId]) {
 async function deleteDashboard([dashboardId]) {
   console.log(`deleting dashboard ${dashboardId}`);
 
-  const optimizeAudience = process.env.OPTIMIZE_AUDIENCE;
-  const accessToken = await getAccessToken("components", optimizeAudience);
-  const optimizeApiUrl = process.env.OPTIMIZE_API_URL;
+  const accessToken = await getAccessToken(authorizationConfiguration);
 
-  const url = `${optimizeApiUrl}/public/dashboard/${dashboardId}`;
+  const optimizeApiUrl = process.env.OPTIMIZE_BASE_URL;
+  const url = `${optimizeApiUrl}/api/public/dashboard/${dashboardId}`;
 
   // Configure the API call.
   const options = {


### PR DESCRIPTION
[BLOCKED]: requires additional changes outside this PR to be merged at roughly the same time.

---


This PR rewrites the auth logic in our API tutorials, to simplify the logic, and to make it more clear to readers how the client ID, secret, and audience are used for authorization.

It also fixes a couple bugs in the Optimize API client code. I'll call these out with inline comments. I'm open to the idea that these bugs should be fixed in a separate PR, so that they don't have to wait for this and its related PRs (described in "Outside impact") to land.

## Outside impact

There are multiple points of impact outside this PR: 

1. ✅  Our associated API tutorial docs will need to be updated to account for these changes. (Christina has done this in https://github.com/camunda/camunda-docs/pull/3708!)
2. #5 will need to be updated with the new approach to authorization. (this can happen in a follow-up PR, because #5 is still in progress.)

## Why are we rewriting the auth logic again?

While walking through #5, and reading comments there, I realized that the reusability I've been trying to accomplish in the auth logic contains an abstraction that is confusing, and also adds complexity to the auth.js logic that distracts readers from understanding how their code acquires authorization tokens.

This new approach to auth removes the abstraction ("administration" APIs vs "component" APIs) in favor of requiring the calling client to pass in its own client ID, secret, and audience. This makes it easier to read the auth.js code, and it makes it more obvious that those three bits are required to authorize an API client. 